### PR TITLE
Run sentry first

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:check": "eslint . --ext .ts",
     "build:check": "tsc -p tsconfig.json",
     "build": "rimraf dist && node build.js",
-    "start": "node ./dist/index.js"
+    "start": "node ./dist/loader.js"
   },
   "devDependencies": {
     "@sentry/cli": "^2.31.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,13 @@
 import { DiscordClient } from "./core/DiscordClient";
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { writeFileSync } from "fs";
 import { flush } from "@sentry/node";
-import {config as dotenv} from "dotenv";
 
 
 /**
  * .env persistance setup for docker
  */
 
-export function saveEnv() {
+function saveEnv() {
   const envToWrite = process.env["WRITE_ENV"];
   if(envToWrite) {
     const envs = envToWrite.replaceAll(' ', '').split(",");
@@ -19,7 +18,6 @@ export function saveEnv() {
   }
 }
 
-dotenv();
 if(process.env['ISDOCKER'])
   saveEnv();
 
@@ -29,14 +27,6 @@ if(process.env['ISDOCKER'])
 
 if(!process.env["BOTTOKEN"])
   throw new Error("No token provided");
-
-if(!process.env["COMMITHASH"]) {
-  // Try to load the commit hash via file
-  if(existsSync("commitHash"))
-    process.env["COMMITHASH"] = readFileSync("commitHash").toString();
-  else
-    console.warn("No commit hash found!");
-}
 
 /**
  * Setup our beloved client stuff and start it
@@ -60,4 +50,3 @@ async function quitSignalHandler() {
 process.on("SIGINT", quitSignalHandler);
 process.on("SIGTERM", quitSignalHandler);
 process.on("SIGQUIT", quitSignalHandler);
-  

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { DiscordClient } from "./core/DiscordClient";
 import { existsSync, readFileSync, writeFileSync } from "fs";
+import { flush } from "@sentry/node";
 import {config as dotenv} from "dotenv";
 
 
@@ -52,6 +53,7 @@ async function quitSignalHandler() {
   await CoreClient.dispose();
   await CoreClient.twitch.dispose();
   await CoreClient.youtube.dispose();
+  await flush(15000);
   process.exit(0);
 }
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -56,7 +56,7 @@ sentryInit({
       
     // Ignore Http Breadcrumbs from the blacklisted url
     if(breadcrumb.category === "http" && 
-            ignoreUrl.filter(url=>breadcrumb.data?.url.startsWith(url)).length > 0) return null;
+      ignoreUrl.filter(url=>breadcrumb.data?.url.startsWith(url)).length > 0) return null;
     return breadcrumb;
   },
       

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,0 +1,93 @@
+/* Software Loader */
+
+// Run Sentry first as required by the docs
+import { expressIntegration, extraErrorDataIntegration, prismaIntegration, rewriteFramesIntegration, init as sentryInit } from "@sentry/node";
+import { DiscordAPIError } from "discord.js";
+import { relative } from "path";
+import { APIErrors } from "./utils/discordErrorCode";
+import { Prisma } from "@prisma/client";
+
+sentryInit({
+  dsn: process.env["SENTRY_DSN"],
+  maxValueLength: 1000,
+  tracesSampleRate: 0.1,
+  
+  integrations: [
+    extraErrorDataIntegration({
+      depth: 5
+    }),
+    rewriteFramesIntegration({
+      iteratee: (frame) => {
+        const absPath = frame.filename;
+        if(!absPath) return frame;
+        // Set the base path as the dist output to match the naming artifact on sentry
+        frame.filename = `/${relative(__dirname, absPath).replace(/\\/g, "/")}`;
+        return frame;
+      }
+    }),
+    prismaIntegration(),
+    expressIntegration(),
+  ],
+      
+  beforeBreadcrumb: (breadcrumb) => {
+    // List of urls to ignore
+    const ignoreUrl = [
+      "https://api.twitch.tv",
+      "https://discord.com",
+      "https://cdn.discordapp.com"
+    ];
+      
+    // Ignore Http Breadcrumbs from the blacklisted url
+    if(breadcrumb.category === "http" && 
+            ignoreUrl.filter(url=>breadcrumb.data?.url.startsWith(url)).length > 0) return null;
+    return breadcrumb;
+  },
+      
+  ignoreErrors: [
+    "ETIMEDOUT",
+    "EADDRINUSE",
+    "ENOTFOUND",
+    "TimeoutError",
+    "AbortError",
+    "NetworkError",
+    "ECONNREFUSED",
+    "ECONNRESET",
+  ],
+  
+  beforeSend : (evnt, hint) => {
+    const ex = hint.originalException;
+    if(ex instanceof DiscordAPIError && ex.code === APIErrors.UNKNOWN_INTERACTION) return null;
+    // Somehow prisma bugged and threw this error :/
+    if(ex instanceof Prisma.PrismaClientKnownRequestError && ex.code === "P1017") return null;
+    return evnt;
+  },
+  
+  release: process.env['COMMITHASH'],
+  environment: process.env["ENVIRONMENT"]
+});
+
+
+// Load OpenTelemetry Config
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { PrismaInstrumentation } from '@prisma/instrumentation';
+import { Resource } from '@opentelemetry/resources';
+
+const provider = new NodeTracerProvider({
+  resource: new Resource({
+    [SEMRESATTRS_SERVICE_NAME]: 'example application',
+  }),
+});
+provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter()));
+
+registerInstrumentations({
+  tracerProvider: provider,
+  instrumentations: [new PrismaInstrumentation()],
+});
+provider.register();
+
+// Start the main software
+import('./index');

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,5 +1,22 @@
 /* Software Loader */
 
+
+// Load Env Variable
+import {config as dotenv} from "dotenv";
+dotenv();
+
+
+// Load Commit Hash
+import {existsSync, readFileSync} from "fs";
+if(!process.env["COMMITHASH"]) {
+  // Try to load the commit hash via file
+  if(existsSync("commitHash"))
+    process.env["COMMITHASH"] = readFileSync("commitHash").toString();
+  else
+    console.warn("No commit hash found!");
+}
+
+
 // Run Sentry first as required by the docs
 import { expressIntegration, extraErrorDataIntegration, prismaIntegration, rewriteFramesIntegration, init as sentryInit } from "@sentry/node";
 import { DiscordAPIError } from "discord.js";


### PR DESCRIPTION
In the current version, Sentry is required to be init before other components for certain tracking to work properly.

It also helps to reduce imports from `core/DiscordClient`...