### PR TITLE
[Requested] Exclude youtube notification

### DIFF
--- a/src/events/YoutubeEvents.ts
+++ b/src/events/YoutubeEvents.ts
@@ -22,8 +22,11 @@ export class YoutubeEvents extends baseYEvent {
   }
 
   private async notified(data: NotifiedEvent) {
-    await this.getChannel();
+    if(!this.NotificationChannel)
+      await this.getChannel();
     if(data.published.getTime() < (new Date().getTime()) - 2592000000 || data.updated.getTime() < (new Date().getTime()) - 2592000000)
+      return;
+    if(data.video.title.toLowerCase().includes("[live]")) // Prevent youtube stream from being posted
       return;
 
     console.log(`Video (${data.video.id}) was notified with Publish: ${data.published} and Updated: ${data.updated}`);
@@ -31,8 +34,6 @@ export class YoutubeEvents extends baseYEvent {
   }
 
   private async subscribe(data: SubEvent) {
-    await this.getChannel();
-
     console.log("Youtube Notification Service: PubSubHubbub has been Subscribed...");
     await this.client.discord.logger.sendLog({
       type: "Info",
@@ -51,8 +52,6 @@ export class YoutubeEvents extends baseYEvent {
   }
 
   private async unsubscribe() {
-    await this.getChannel();
-
     console.log("Youtube Notification Service: Even has been unsubscribed, resubscribing...");
     await this.client.discord.logger.sendLog({
       type: "Warning",

--- a/src/events/streamEvents.ts
+++ b/src/events/streamEvents.ts
@@ -47,7 +47,8 @@ export class StreamEvents extends baseTEvent {
       .setURL(streamUrl)
       .setImage(data.thumbnail_url);
 
-    await channel.send({content: `<@${this.config.notification.roleToPing}> Derg is streaming right now, come join!`, embeds: [embed]});
+    const roleID = this.config.notification.roleToPing;
+    await channel.send({content: `${roleID === "everyone" ? "@everyone" : `<@&${roleID}`} Derg is streaming right now, come join!`, embeds: [embed]});
   }
 
   private async onStreamEnd() {

--- a/src/utils/DiscordInvite.ts
+++ b/src/utils/DiscordInvite.ts
@@ -71,7 +71,8 @@ export class DiscordInvite {
      * Create a templorary reusable invite link if vanity URL does not exist
      * @param inviteOpt Discord.js's Create Invite Options and the
      * default value for maxAge is 1 day
-     * @param rawCode Whether to return an invite code or a full invite link
+     * @param rawCode Whether to return an invite code or a full invite link (inside inviteOpt)
+     * @param nocache Whether to ignore the cache and create a new invite (inside inviteOpt)
      * @returns The invite link or the code
      */
   public async getTempInvite(inviteOpt?: tempInviteOption) {


### PR DESCRIPTION
adding `[live]` tag in a youtube video, or specifically, live stream, will no longer cause youtube notification to be posted