### PR TITLE
preload font for node-canvas on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ WORKDIR /app/
 # Install/upgrade some system packages
 RUN apt-get update
 #RUN apt-get install fonts-noto ffmpeg -y
-RUN apt-get install fonts-noto -y
+RUN apt-get install fonts-open-sans -y
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy files from the build env

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { logger, close, startNewTrace } from "@sentry/node";
 import { discordCli, svcClient, TwitchCli, YoutubeCli } from "./SharedClient";
+import { preload } from "./utils/bannerGen";
 
 /**
  * Start up checks
@@ -16,6 +17,7 @@ if(!process.env["TWITCH_TOKEN"] || !process.env["TWITCH_USERNAME"])
 startNewTrace(async () => {
   // PRE PROCESSING EVENTS
   svcClient.preProcess();
+  preload();
 
   await svcClient.start();
   await discordCli.start(process.env["BOTTOKEN"]!);

--- a/src/utils/bannerGen.ts
+++ b/src/utils/bannerGen.ts
@@ -76,14 +76,13 @@ export class BannerPic {
     */
   private setText(name: string) {
     const ctx = this.canvas.getContext("2d");
-    // Use fonts-noto on linux system and sans-serif on windows for character display compatibility
     ctx.fillStyle = "white";
     ctx.textAlign = "center";
     ctx.shadowColor = "black";
     ctx.shadowBlur = 10;
-    ctx.font = "30px fonts-noto, sans-serif";
+    ctx.font = "30px sans-serif";
     ctx.fillText(name, this.canvas.width/2, this.canvas.height/3 + 110);
-    ctx.font = "22px fonts-noto, sans-serif, segoe-ui-emoji";
+    ctx.font = "22px sans-serif";
     ctx.fillText("Welcome to Firey's server! I hope you enjoy your stay here (σ`・∀・)σ", this.canvas.width/2, this.canvas.height/3 + 150);
   }
 
@@ -122,8 +121,8 @@ export class BannerPic {
 /** Use this to preload all the font so that the first banner generation, since startup, wouldnt take too long */
 export function preload() {
   const ctx = createCanvas(1,1).getContext("2d");
-  ctx.font = "30px fonts-noto, sans-serif";
+  ctx.font = "30px sans-serif";
   ctx.fillText("", 0, 0);
-  ctx.font = "22px fonts-noto, sans-serif, segoe-ui-emoji";
+  ctx.font = "22px sans-serif";
   ctx.fillText("", 0, 0);
 }

--- a/src/utils/bannerGen.ts
+++ b/src/utils/bannerGen.ts
@@ -118,3 +118,12 @@ export class BannerPic {
     ctx.drawImage(pfp, this.canvas.width/2 - hsx,this.canvas.height/3 - hsy, hsx*2, hsy*2);
   }
 }
+
+/** Use this to preload all the font so that the first banner generation, since startup, wouldnt take too long */
+export function preload() {
+  const ctx = createCanvas(1,1).getContext("2d");
+  ctx.font = "30px fonts-noto, sans-serif";
+  ctx.fillText("", 0, 0);
+  ctx.font = "22px fonts-noto, sans-serif, segoe-ui-emoji";
+  ctx.fillText("", 0, 0);
+}


### PR DESCRIPTION
- Use open sans font (somehow font-noto renders weird?)
- preload font data on startup so that first banner generation wouldnt take a whole minute to generate...